### PR TITLE
add option to use Random.org for random engine #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
       "**/?(*.)test.ts"
     ],
     "testEnvironment": "node"
+  },
+  "dependencies": {
+    "axios": "^0.18.0"
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -37,7 +37,44 @@ describe("The main test suite", () => {
       values.forEach(value => {
         expect(allowedValues).toContain(value);
       });
+    });
+  });
 
+  describe("The good, properly formatted cases (using Random.org)", () => {
+    test("Works with 1d6, returns a properly formatted object within limits", async () => {
+      const result = await roll("1d6", { useRandomOrg: true });
+      // Assert the right object properties exist
+      expect(result.total).toBeGreaterThanOrEqual(1);
+      // @ts-ignore, I know it might not be defined, the test will show it
+      expect(result.rolls.length).toBe(1);
+      // @ts-ignore
+      expect(result.rolls[0].order).toBe(1);
+      // @ts-ignore
+      expect(result.rolls[0].sides).toBe(6);
+      // @ts-ignore
+      expect(result.rolls[0].result).toBeGreaterThanOrEqual(1);
+      // @ts-ignore
+      expect(result.rolls[0].result).toBeLessThanOrEqual(6);
+    });
+    test("Works with a large number of throws (100)", async () => {
+      const result = await roll("100d20", { useRandomOrg: true });
+      // Expect 103 assertions cause checking each throw
+      expect.assertions(103);
+      // Expect the total of 100 throws of 20 side dice to be between 100 and 2000
+      expect(result.total).toBeGreaterThanOrEqual(100);
+      expect(result.total).toBeLessThanOrEqual(100 * 20);
+      expect(result.rolls).toHaveLength(100);
+
+      // Extract values, make sure they're all between 1 and 20
+      // @ts-ignore
+      const values = result.rolls.map(item => item.result);
+      // Create a 'valid rolls' array, from 1 to 20 inclusive
+      const allowedValues = Array.from(Array(21).keys()).slice(1);
+
+      // Check [1,2,..20] contains each result
+      values.forEach(value => {
+        expect(allowedValues).toContain(value);
+      });
     });
   });
 
@@ -66,6 +103,39 @@ describe("The main test suite", () => {
       expect.assertions(1);
       try {
         await roll("abc");
+      } catch (e) {
+        expect(e).toBe(
+          "Not a valid roll notation, needs to be integer, d, integer, e.g. 4d20"
+        );
+      }
+    });
+  });
+
+  describe("The bad, badly formatted cases (using Random.org)", () => {
+    test("Returns a correct error whe n passed 'd2'", async () => {
+      expect.assertions(1);
+      try {
+        await roll("d2", { useRandomOrg: true });
+      } catch (e) {
+        expect(e).toBe(
+          "Not a valid roll notation, needs to be integer, d, integer, e.g. 4d20"
+        );
+      }
+    });
+    test("Returns a correct error whe n passed '2d'", async () => {
+      expect.assertions(1);
+      try {
+        await roll("2d", { useRandomOrg: true });
+      } catch (e) {
+        expect(e).toBe(
+          "Not a valid roll notation, needs to be integer, d, integer, e.g. 4d20"
+        );
+      }
+    });
+    test("Returns a correct error whe n passed 'abc'", async () => {
+      expect.assertions(1);
+      try {
+        await roll("abc", { useRandomOrg: true });
       } catch (e) {
         expect(e).toBe(
           "Not a valid roll notation, needs to be integer, d, integer, e.g. 4d20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,6 +177,13 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -574,15 +581,15 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.1.0"
     whatwg-url "^7.0.0"
 
-debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+debug@=3.1.0, debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -888,6 +895,12 @@ find-up@^2.1.0:
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
     locate-path "^2.0.0"
+
+follow-redirects@^1.3.0:
+  version "1.5.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.8.tgz#1dbfe13e45ad969f813e86c00e5296f525c885a1"
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR implements the `useRandomOrg` option on the `roll()` function, which can be called as such:
`roll("2d20", { useRandomOrg: true });`

For the tests, since the end result shouldn't be different I just copied the existing tests and added the config. This does have the consequence of making them take longer to run, which can be mitigated by using a [mock of the Random.org query](https://jestjs.io/docs/en/tutorial-async). If you want I can toss that in here tomorrow!